### PR TITLE
Add filter

### DIFF
--- a/l2l/templates/l2l/index.html
+++ b/l2l/templates/l2l/index.html
@@ -1,5 +1,5 @@
 {% load static %}
-{#{% load l2l_extras %}#}
+{% load l2l_extras %}
 <!doctype html>
 <html lang="en">
     <head>
@@ -57,8 +57,8 @@
           <p class="lead fw-normal">Yes this is a rip-off from one of Bootstrap's example html pages.</p>
           <p class="lead fw-normal">Today's date is: {{ now }}</p>
           <p class="lead fw-normal">Today's ISO date is: {{ iso }}</p>
-          {#<p class="lead fw-normal">Today's date from a date is: {{ now|l2l_dt }}</p>#}
-          {#<p class="lead fw-normal">Today's date from a string is: {{ iso|l2l_dt }}</p>#}
+          <p class="lead fw-normal">Today's date from a date is: {{ now|l2l_dt }}</p>
+          <p class="lead fw-normal">Today's date from a string is: {{ iso|l2l_dt }}</p>
           <a class="btn btn-outline-secondary" href="#">Coming soon</a>
         </div>
         <div class="product-device shadow-sm d-none d-md-block"></div>

--- a/l2l/templates/l2l/index.html
+++ b/l2l/templates/l2l/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="generator" content="">
-    <title>Sample Web App</title>    
+    <title>John - Date Formatter</title>    
 
     <!-- Bootstrap core CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -53,12 +53,14 @@
     <main>
       <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center bg-light">
         <div class="col-md-5 p-lg-5 mx-auto my-5">
-          <h1 class="display-4 fw-normal">Punny headline</h1>
+          <h1 class="display-4 fw-normal">John's Amazing Date Formatter 3000</h1>
           <p class="lead fw-normal">Yes this is a rip-off from one of Bootstrap's example html pages.</p>
           <p class="lead fw-normal">Today's date is: {{ now }}</p>
           <p class="lead fw-normal">Today's ISO date is: {{ iso }}</p>
+          <p class="lead fw-normal">Today's date from an invalid string is: {{ invalid_now }}</p>
           <p class="lead fw-normal">Today's date from a date is: {{ now|l2l_dt }}</p>
           <p class="lead fw-normal">Today's date from a string is: {{ iso|l2l_dt }}</p>
+          <p class="lead fw-normal">Today's date from an invalid string is: {{ invalid_now|l2l_dt }}</p>
           <a class="btn btn-outline-secondary" href="#">Coming soon</a>
         </div>
         <div class="product-device shadow-sm d-none d-md-block"></div>

--- a/l2l/templatetags/__init__.py
+++ b/l2l/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory as a package

--- a/l2l/templatetags/l2l_extras.py
+++ b/l2l/templatetags/l2l_extras.py
@@ -24,7 +24,12 @@ def l2l_dt(value):
             dt = datetime.fromisoformat(value)
             return dt.strftime("%Y-%m-%d %H:%M:%S")
     
+    except (ValueError, TypeError, AttributeError):
+        # We expect these when parsing bad date strings
+        # log.warning(f"l2l_dt filter couldn't parse value: {value}")
+        return value
+    
     except Exception as e:
         # consider logging error with logger library. ie:
         # log.error(f"Error in l2l_dt filter: {e}")
-        return value
+        raise

--- a/l2l/templatetags/l2l_extras.py
+++ b/l2l/templatetags/l2l_extras.py
@@ -1,0 +1,30 @@
+from django import template
+from datetime import datetime
+
+register = template.Library()
+
+@register.filter
+def l2l_dt(value):
+    """
+    Custom template filter for formatting dates/times.
+    
+    Should handle both input types:
+    - datetime objects 
+    - ISO date strings
+    Returns formatted string "YYYY-MM-DD HH:MM:SS" or original value on error.
+
+    """
+    try:
+        # if value is datetime object
+        if isinstance(value, datetime):
+            return value.strftime("%Y-%m-%d %H:%M:%S")
+        
+        # if value is ISO date string
+        elif isinstance(value, str):
+            dt = datetime.fromisoformat(value)
+            return dt.strftime("%Y-%m-%d %H:%M:%S")
+    
+    except Exception as e:
+        # consider logging error with logger library. ie:
+        # log.error(f"Error in l2l_dt filter: {e}")
+        return value

--- a/l2l/templatetags/l2l_extras.py
+++ b/l2l/templatetags/l2l_extras.py
@@ -23,10 +23,11 @@ def l2l_dt(value):
         elif isinstance(value, str):
             dt = datetime.fromisoformat(value)
             return dt.strftime("%Y-%m-%d %H:%M:%S")
-    
-    except (ValueError, TypeError, AttributeError):
+
+    except (ValueError, TypeError, AttributeError) as e:
         # We expect these when parsing bad date strings
-        # log.warning(f"l2l_dt filter couldn't parse value: {value}")
+        # consider logging with logger library. ie:
+        # log.warning(f"l2l_dt filter couldn't parse value: {value}, exception: {e}")
         return value
     
     except Exception as e:

--- a/l2l/tests.py
+++ b/l2l/tests.py
@@ -47,3 +47,6 @@ class L2LDateTimeFilterTests(TestCase):
         result_dt = l2l_dt(self.test_datetime)
         result_str = l2l_dt(self.test_iso_string)
         self.assertEqual(result_dt, result_str)
+
+    # Additional (possibly overkill) test cases to consider:
+    # Handling different timezones, various ISO formats, unexpected types

--- a/l2l/tests.py
+++ b/l2l/tests.py
@@ -1,3 +1,49 @@
 from django.test import TestCase
+from datetime import datetime
+from l2l.templatetags.l2l_extras import l2l_dt
 
-# Create your tests here.
+
+class L2LDateTimeFilterTests(TestCase):
+    """
+    Test cases for the l2l_dt custom template filter.
+    
+    The filter should handle:
+    - datetime objects
+    - ISO date strings
+    - Invalid inputs gracefully
+    """
+    
+    def setUp(self):
+        self.test_datetime = datetime(2025, 9, 1, 14, 30, 0)  # Sept 1, 2025 at 2:30 PM
+        self.test_iso_string = "2025-09-01T14:30:00"
+        self.test_invalid_date = "Sptmbr 1nd, 20252"
+        self.test_invalid_string = "hello world"
+        self.test_none = None
+        self.test_empty_string = ""
+        
+        self.expected_format = "2025-09-01 14:30:00"
+
+        # Note: No need to test invalid datetime object such as datetime(2025, 13, 1, 14, 30, 0)
+        # Causes the test itself to error out while constructing the test case.
+
+    def test_filter_with_datetime_object(self):
+        # Test that the filter correctly handles datetime objects
+        result = l2l_dt(self.test_datetime)
+        self.assertEqual(result, self.expected_format)
+
+    def test_filter_with_iso_string(self):
+        # Test that the filter correctly handles ISO date strings
+        result = l2l_dt(self.test_iso_string)
+        self.assertEqual(result, self.expected_format)
+    
+    def test_filter_with_invalid_input(self):
+        # Test with invalid inputs like None, empty string, invalid date format, invalid datetime object
+        for invalid_input in [self.test_none, self.test_empty_string, self.test_invalid_date, self.test_invalid_string]:
+            result = l2l_dt(invalid_input)
+            self.assertEqual(result, invalid_input)
+
+    def test_filter_consistency(self):
+        # Test that datetime object and equivalent ISO string produce same result
+        result_dt = l2l_dt(self.test_datetime)
+        result_str = l2l_dt(self.test_iso_string)
+        self.assertEqual(result_dt, result_str)

--- a/l2l/views.py
+++ b/l2l/views.py
@@ -9,6 +9,7 @@ def index(request):
     template = loader.get_template('l2l/index.html')
     context = {
         'iso': now.strftime("%Y-%m-%dT%H:%M:%S"),
-        'now': now
+        'now': now,
+        'invalid_now': 'September 32nd, 2025'
     }
     return HttpResponse(template.render(context, request))

--- a/testsite/settings.py
+++ b/testsite/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = '8d^qo$f_n27u%$-8$nh8s8kx+cxz_)1nxhlthc(&@v^guy)z8h'
 DEBUG = True
 
 from socket import gethostname, gethostbyname 
-ALLOWED_HOSTS = [gethostname(), gethostbyname(gethostname()), 'localhost']
+ALLOWED_HOSTS = [gethostname(), gethostbyname(gethostname()), 'localhost', '0.0.0.0']
 
 
 # Application definition


### PR DESCRIPTION
- adds a date filter that handles datetime objects and strings as input, gracefully handles invalid inputs
- shows filter functionality on frontend, including adding an example for invalid inputs
- adds test for l2l_dt filter
- could log warnings for invalid inputs or raise exceptions for more serious errors
- edited title and header